### PR TITLE
Update sample-bot.cfg

### DIFF
--- a/sample-bot.cfg
+++ b/sample-bot.cfg
@@ -2,7 +2,7 @@
 node = http://nodes.wavesnodes.com
 # select the network: testnet or mainnet
 network = mainnet
-matcher = http://matcher.wavesnodes.com
+matcher = https://matcher.waves.exchange
 order_fee = 300000
 order_lifetime = 86400
 


### PR DESCRIPTION
replacing the old matcher address with the new one. With the old matcher address, bot halts on 
grid initialization.
